### PR TITLE
feat(leo): add optimal-foreground mode for on_ token derivation

### DIFF
--- a/docs/examples/leonardo.md
+++ b/docs/examples/leonardo.md
@@ -12,9 +12,10 @@ This example demonstrates contrast-aware color generation using [Adobe Leonardo]
 
 1. `leo()` takes a color family ref (or raw hex) and a target contrast ratio
 2. Leonardo generates a color that hits the specified contrast against the background surface
-3. Supports two modes:
+3. Supports three modes:
    - **Family mode** — pass a `{palette.family.*}` ref; the resolver extracts the key color and default background from the family group
    - **Direct mode** — pass a raw color value with an explicit `$background`
+   - **Foreground mode** — pass `optimal-foreground` as the contrast parameter to select black or white for maximum readability on the given background
 
 ## Usage Examples
 
@@ -41,6 +42,15 @@ leo(#4f6afc, 4.5, #ffffff, apca)   → #4f6afc
 ```
 
 Raw hex input, explicit background, APCA contrast model. Useful when working outside the palette system.
+
+### Foreground selection — optimal-foreground mode
+
+```scss
+leo({palette.blue.700}, optimal-foreground)   → #ffffff
+leo({palette.gray.300}, optimal-foreground)   → #000000
+```
+
+Selects black or white for maximum readability on the given background. Uses APCA by default, accounting for the Helmholtz-Kohlrausch effect on saturated chromatic midtones. This is the formula behind `on_` palette tokens.
 
 ## DTCG Extension
 

--- a/examples/leonardo-color/color.module.scssdef
+++ b/examples/leonardo-color/color.module.scssdef
@@ -9,24 +9,35 @@ see: [builtins]
 ---
 
 /// @name leo
-/// @summary Generate a color at a target contrast using Leonardo.
-/// @description Supports two modes. In family mode, pass a color family ref
-///   as $color — the resolver extracts the key color and default background
-///   from the family group. In direct mode, pass a raw color value as $color
-///   with an explicit $background. In both modes, $contrast is the target
-///   contrast ratio between the generated color and the background surface.
-///   Family mode: leo({palette.family.blue}, 4.5) → family color at 4.5 contrast.
-///   Direct mode: leo(#4f6afc, 4.5, #ffffff) → ad-hoc contrast color.
-/// @param $color <ref|color> Color family ref or raw key color value.
-/// @param $contrast <number> Target contrast ratio between generated color and background.
-/// @param $background <color|ref> Contrast surface. Defaults to white when family background is unavailable.
+/// @summary Generate a color at a target contrast, or select optimal foreground.
+/// @description Supports three modes:
+///   **Family mode** — pass a color family ref as $color; the resolver extracts
+///   the key color and default background from the family group.
+///   **Direct mode** — pass a raw color value as $color with an explicit $background.
+///   **Foreground mode** — pass `optimal-foreground` as $contrast to select black
+///   or white for maximum readability on $color as background. Accounts for the
+///   Helmholtz-Kohlrausch effect on saturated chromatic colors via APCA.
+///   In family and direct modes, $contrast is the target contrast ratio between
+///   the generated color and the background surface.
+/// @param $color <ref|color> Color family ref, raw key color, or background color (foreground mode).
+/// @param $contrast <number|optimal-foreground> Target contrast ratio, or keyword for foreground selection.
+/// @param $background <color|ref> Contrast surface. Defaults to white. Ignored in foreground mode.
 /// @param $model <apca|wcag2|wcag3> Contrast algorithm. Default apca.
 /// @returns <color>
-/// @constraints $contrast > 0
+/// @constraints $contrast > 0 when numeric
 /// @example leo({palette.family.blue}, 60) → #4f6afc
 /// @example leo({palette.family.blue}, 45, #1a1a2e) → #8fa4ff
 /// @example leo(#4f6afc, 4.5, #ffffff, wcag2) → #4f6afc
+/// @example leo({palette.blue.700}, optimal-foreground) → #ffffff
+/// @example leo({palette.gray.300}, optimal-foreground) → #000000
 /// @since 0.1.0
 @function leo($color, $contrast, $background: white, $model: apca) {
+  @if $contrast == optimal-foreground {
+    @return if(
+      leonardo-contrast($color, white, $model) > leonardo-contrast($color, black, $model),
+      white,
+      black
+    );
+  }
   @return leonardo($color, $contrast, $background, $model);
 }


### PR DESCRIPTION
## Summary

Extends `leo()` to accept `optimal-foreground` as the `$contrast` parameter, making it the single entry point for all contrast-aware color operations.

## New mode

```scss
leo({palette.blue.700}, optimal-foreground) → #ffffff
leo({palette.gray.300}, optimal-foreground) → #000000
```

Selects black or white for maximum readability on a given background using APCA (default). This is the formula behind `on_` palette tokens in the design system.

## Why

The design system has 99 `on_` tokens that need formula provenance. Rather than creating a separate `on-color()` wrapper function, `leo()` should be the de-facto entry point for all contrast operations — both target-ratio generation and foreground selection.

## Changes
- `color.module.scssdef` — add `optimal-foreground` branch to `leo()`
- `docs/examples/leonardo.md` — document foreground mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)