### PR TITLE
feat: add composite() function + clarify leo() foreground mode

### DIFF
--- a/examples/compositing/composite.module.scssdef
+++ b/examples/compositing/composite.module.scssdef
@@ -1,0 +1,35 @@
+---
+module: composite
+title: Alpha Compositing
+summary: Porter-Duff over operator for compositing translucent colors onto opaque canvases.
+category: color
+since: 0.1.0
+tags: [color, alpha, compositing, contrast, accessibility]
+see: [leonardo-color]
+---
+
+/// @name composite
+/// @summary Alpha-composite a translucent color over an opaque canvas (Porter-Duff over).
+/// @description Use when a design token applies an alpha modifier to a palette color
+///   and you need the effective visible color for downstream computation (e.g.,
+///   contrast selection via `leo()`). The result is always fully opaque.
+///
+///   Common pattern with `leo()`:
+///   ```
+///   leo(composite({palette.gray.500}, 0.1, {semantic.surface.canvas}), optimal-foreground)
+///   ```
+///   This composites the translucent semantic background over the theme canvas,
+///   then selects the APCA-optimal foreground (black or white) for that effective color.
+/// @param $color <color|ref> Source color before alpha application.
+/// @param $alpha <number> Opacity in [0, 1].
+/// @param $canvas <color|ref> Opaque surface to composite over (e.g., {semantic.surface.canvas}).
+/// @returns <color> Fully opaque composited result.
+/// @constraints $alpha >= 0, $alpha <= 1
+/// @example composite(#767676, 0.1, #e6e6e6) → #dbdbdb
+/// @example composite(#c8c8c8, 0.05, #111111) → #1a1a1a
+/// @example composite(#4f6afc, 0.07, #e6e6e6) → #dbdde8
+/// @example composite(#ff8078, 0.15, #111111) → #352220
+/// @since 0.1.0
+@function composite($color, $alpha, $canvas) {
+  @return mix($color, $canvas, $alpha);
+}

--- a/examples/leonardo-color/color.module.scssdef
+++ b/examples/leonardo-color/color.module.scssdef
@@ -15,8 +15,11 @@ see: [builtins]
 ///   the key color and default background from the family group.
 ///   **Direct mode** — pass a raw color value as $color with an explicit $background.
 ///   **Foreground mode** — pass `optimal-foreground` as $contrast to select black
-///   or white for maximum readability on $color as background. Accounts for the
-///   Helmholtz-Kohlrausch effect on saturated chromatic colors via APCA.
+///   or white for maximum readability on $color as background. Always returns
+///   pure `black` (#000000) or `white` (#ffffff) — no intermediate values.
+///   Accounts for the Helmholtz-Kohlrausch effect on saturated chromatic colors
+///   via APCA. When $color is a composited result (e.g., from `composite()`),
+///   the foreground is computed against the effective visible color.
 ///   In family and direct modes, $contrast is the target contrast ratio between
 ///   the generated color and the background surface.
 /// @param $color <ref|color> Color family ref, raw key color, or background color (foreground mode).
@@ -30,6 +33,8 @@ see: [builtins]
 /// @example leo(#4f6afc, 4.5, #ffffff, wcag2) → #4f6afc
 /// @example leo({palette.blue.700}, optimal-foreground) → #ffffff
 /// @example leo({palette.gray.300}, optimal-foreground) → #000000
+/// @example leo(composite({palette.gray.500}, 0.1, {semantic.surface.canvas}), optimal-foreground) → #000000
+/// @example leo(composite({palette.blue.500}, 0.15, {semantic.surface.canvas}), optimal-foreground) → #ffffff
 /// @since 0.1.0
 @function leo($color, $contrast, $background: white, $model: apca) {
   @if $contrast == optimal-foreground {


### PR DESCRIPTION
## Summary

- Adds `composite()` function (`examples/compositing/composite.module.scssdef`) — Porter-Duff alpha compositing for translucent colors over opaque canvases
- Clarifies `leo()` foreground mode: `optimal-foreground` always returns pure black or white, works with composited inputs
- Adds composed examples showing `leo(composite(...), optimal-foreground)`

## Motivation

[DSYS-425](https://linear.app/underline/issue/DSYS-425): semantic on-* tokens were computed against opaque palette shades instead of the alpha-composited effective color over `surface.canvas`. The `composite()` function formalizes this computation so formula metadata can document the full derivation chain:

```json
{
  "call": "leo(composite({palette.blue.500}, 0.15, {semantic.surface.canvas}), optimal-foreground, apca)"
}
```

## Changes

### New: `examples/compositing/composite.module.scssdef`
- `composite($color, $alpha, $canvas)` → fully opaque composited result
- Documented with common `leo()` composition pattern

### Updated: `examples/leonardo-color/color.module.scssdef`
- Clarified `optimal-foreground` returns only pure black/white (no intermediates)
- Added note about composited input support
- Added 2 composed examples with `composite()`