### PR TITLE
feat: add outline-radius() formula (DSYS-431)

### DIFF
--- a/examples/outline-radius/outline-radius.module.scssdef
+++ b/examples/outline-radius/outline-radius.module.scssdef
@@ -1,0 +1,33 @@
+---
+module: outline-radius
+title: Outline Radius Compensation
+summary: Outer-edge radius of a CSS outline with offset, for reproducing the silhouette in tools without native outline support.
+category: geometry
+since: 0.2.0
+tags: [radius, outline, figma, geometry, tokens]
+see: [radius]
+---
+
+/// @name outline-radius
+/// @summary Outer-edge radius of an offset outline's visual silhouette.
+/// @description Matches how modern browsers render a CSS `outline` when
+///              `outline-offset` is set on an element with `border-radius`:
+///              the outline's corners follow the element's curvature and
+///              expand outward by the offset plus the outline width.
+///              Use this to drive the corner radius of a compensating
+///              rectangle in tools (e.g., Figma) that cannot natively
+///              render `outline-offset`. FE consumers should ignore this —
+///              the browser computes it automatically.
+/// @param $inner <dimension|ref> Inner element's border-radius.
+/// @param $offset <dimension|ref> The `outline-offset` value.
+/// @param $width <dimension|ref> The `outline-width` value.
+/// @returns <dimension>
+/// @constraints $inner >= 0
+/// @constraints $offset >= 0
+/// @constraints $width > 0
+/// @example outline-radius(20px, 4px, 2px) → 26px
+/// @example outline-radius(8px, 4px, 2px) → 14px
+/// @example outline-radius(0px, 4px, 2px) → 6px
+@function outline-radius($inner, $offset, $width) {
+  @return $inner + $offset + $width;
+}

--- a/packages/parser/__tests__/parse.test.ts
+++ b/packages/parser/__tests__/parse.test.ts
@@ -101,6 +101,52 @@ describe('parse()', () => {
     });
   });
 
+  describe('outline-radius/outline-radius.module.scssdef', () => {
+    const result = parse(readExample('outline-radius/outline-radius.module.scssdef'));
+
+    it('parses frontmatter with geometry category and see:[radius]', () => {
+      expect(result.frontmatter.module).toBe('outline-radius');
+      expect(result.frontmatter.category).toBe('geometry');
+      expect(result.frontmatter.see).toEqual(['radius']);
+    });
+
+    it('extracts the outline-radius function', () => {
+      expect(result.functions).toHaveLength(1);
+      const fn = result.functions[0];
+      expect(fn.name).toBe('outline-radius');
+      expect(fn.summary).toBe("Outer-edge radius of an offset outline's visual silhouette.");
+    });
+
+    it('parses 3 positional parameters', () => {
+      const fn = result.functions[0];
+      expect(fn.parameters).toHaveLength(3);
+      expect(fn.parameters[0].name).toBe('inner');
+      expect(fn.parameters[1].name).toBe('offset');
+      expect(fn.parameters[2].name).toBe('width');
+      expect(fn.parameters.every((p) => p.default === null)).toBe(true);
+    });
+
+    it('parses non-negativity and positivity constraints', () => {
+      expect(result.functions[0].constraints).toEqual([
+        '$inner >= 0',
+        '$offset >= 0',
+        '$width > 0',
+      ]);
+    });
+
+    it('parses return expression as the sum of all three params', () => {
+      expect(result.functions[0].returnExpression).toBe('$inner + $offset + $width');
+    });
+
+    it('parses 3 examples covering friendly, rounded, and sharp shapes', () => {
+      const examples = result.functions[0].examples!;
+      expect(examples).toHaveLength(3);
+      expect(examples[0]).toBe('outline-radius(20px, 4px, 2px) → 26px');
+      expect(examples[1]).toBe('outline-radius(8px, 4px, 2px) → 14px');
+      expect(examples[2]).toBe('outline-radius(0px, 4px, 2px) → 6px');
+    });
+  });
+
   describe('builtins/clamp.module.scssdef', () => {
     const result = parse(readExample('builtins/clamp.module.scssdef'));
 


### PR DESCRIPTION
Closes [DSYS-431](https://linear.app/underline/issue/DSYS-431/add-outline-radius-formula-to-dtcg-formulas).

## Summary

New `examples/outline-radius/outline-radius.module.scssdef` defining:

```scss
@function outline-radius($inner, $offset, $width) {
  @return $inner + $offset + $width;
}
```

The outer-edge radius of a CSS outline with offset. Designers reproducing a CSS `outline` + `outline-offset` visual in Figma (or any tool that can't render `outline-offset`) need a computed radius for the compensating rect so its corners follow the element's curvature outward. Modern browsers auto-round outline corners to the same geometry — the formula just surfaces the math for the tool chain.

## Why

First consumer is Card's `selected` state in [nrfta/design-system#389](https://github.com/nrfta/design-system/pull/389) (DSYS-428). With a shape-scale of three inner radii (`friendly` 20px, `rounded` 8px, `sharp` 0px) and a fixed 4px offset + 2px outline, the compensating rect radii resolve to 26px, 14px, 6px respectively. Computed via `outline-radius()` rather than hand-typed, so they're recomputed correctly if any input shifts.

## Pattern

Sibling of #19's `fluid-size`/`material-shadow` additions and the prior `radius` module. Same DTCG JSDoc convention: frontmatter + `@name`/`@summary`/`@description`/`@param`/`@returns`/`@constraints`/`@example` + single `@function`.

## Testing

- [x] \`npm test\` — all 6 new assertions in \`packages/parser/__tests__/parse.test.ts\` pass
- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean

Pre-existing 2 failures in \`leonardo-color\` test block are unrelated (drift from the APCA default commit 38c5118).

## Notes

- FE consumers should **ignore** \`outline-radius\` tokens downstream. Browsers compute the visual from \`border-radius + outline-offset\` automatically. The formula exists for Figma parity.
- Three \`@example\` lines pin the output for friendly/rounded/sharp shapes so future resolver work has a fixture.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)