### PR TITLE
docs: audit follow-up — api/index, guide/index, vision

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,7 +4,12 @@
 
 | Package | Description | Status |
 |---------|-------------|--------|
-| [`@dtcg-formulas/parser`](./parser) | Parse `.module.scssdef` definition files | Phase 1 |
-| [`@dtcg-formulas/registry`](./registry) | Function declaration registry with built-in support | Phase 1 |
-| `@dtcg-formulas/resolver` | Scalar formula resolution engine | Phase 2 |
-| `@dtcg-formulas/style-dictionary-plugin` | Style Dictionary integration | Phase 2 |
+| [`@dtcg-formulas/parser`](./parser) | Parse `.module.scssdef` definition files | [0.1.0 on npm](https://www.npmjs.com/package/@dtcg-formulas/parser) |
+| [`@dtcg-formulas/registry`](./registry) | Function declaration registry with built-in support | [0.1.0 on npm](https://www.npmjs.com/package/@dtcg-formulas/registry) |
+| `@dtcg-formulas/spec` | Specifications (`.module.scssdef`, extension, registry) | [0.1.0 on npm](https://www.npmjs.com/package/@dtcg-formulas/spec) |
+| `@dtcg-formulas/resolver` | Pure compute core: walks DTCG tokens, resolves refs, writes `$value` | 0.2.0 |
+| `@dtcg-formulas/builtins` | Executable JS implementations for math built-ins | 0.2.0 |
+| `@dtcg-formulas/cli` | `compile` / `lint` / `check` CLI over the resolver | 0.2.0 |
+| `@dtcg-formulas/style-dictionary-plugin` | Style Dictionary integration | 0.3.0 |
+
+See the [roadmap](/guide/roadmap) for the full phased plan.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -37,7 +37,7 @@ A design token should be able to contain:
        └───────────┬────────────┘
                    ▼
               ┌──────────┐
-              │ Resolver │  (Phase 2)
+              │ Resolver │  (0.2.0)
               └──────────┘
 ```
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -226,12 +226,12 @@ A generator produces multiple values or token groups from one definition. Genera
 See the actual repo layout. Summary:
 
 ```
-/packages/spec/          Specifications
-/packages/parser/        Parser (stub)
-/packages/registry/      Registry (stub)
-/packages/resolver/      Resolver (stub)
-/packages/docs/          Docs generator (stub)
-/packages/style-dictionary-plugin/  SD integration (stub)
+/packages/spec/          Specifications (0.1.0 on npm)
+/packages/parser/        Parser (0.1.0 on npm)
+/packages/registry/      Registry (0.1.0 on npm)
+/packages/resolver/      Resolver (planned 0.2.0)
+/packages/docs/          Docs generator (planned 0.3.0)
+/packages/style-dictionary-plugin/  SD integration (planned 0.3.0)
 /examples/radius/        Radius + math example
 /examples/spacing/       Spacing example (stub)
 /examples/leonardo-color/ Leonardo color example


### PR DESCRIPTION
Follow-up audit fixes that should have landed in PR #28 but were pushed after the merge. Three doc pages with stale "Phase 1/Phase 2" or "(stub)" labels referencing the project's release state.

## Summary

- **docs/api/index.md** — "Phase 1" / "Phase 2" replaced with concrete versions and npm links; added rows for `@dtcg-formulas/spec`, `/builtins`, `/cli`
- **docs/guide/index.md** — architecture diagram label `(Phase 2)` → `(0.2.0)`
- **docs/vision.md** — repository-structure block: parser/registry/spec → "0.1.0 on npm"; resolver/docs/SD-plugin → "planned 0.2.0/0.3.0" (still stubs — that part wasn't stale)

## Verification

- `npm run docs:build` — clean
- `npm run check` (biome) — clean

No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQMhJvH11g1zRCA9MmwWHo)_