### PR TITLE
spec: rename org.dtcg-formulas key from &quot;call&quot; to &quot;formula&quot;

### DIFF
--- a/.changeset/spec-rename-call-to-formula.md
+++ b/.changeset/spec-rename-call-to-formula.md
@@ -1,0 +1,7 @@
+---
+'@dtcg-formulas/spec': patch
+---
+
+Rename the `org.dtcg-formulas` extension call-string key from `"call"` to `"formula"`. The README, every example, and every user-facing doc page already used `"formula"`; the spec source was the only holdout. This is a clarifying alignment, not a wire-format break: the syntax version stays at `scssdef@0.1` because no public tooling consumed either key at runtime in 0.1.0.
+
+Tools and authors should now use `"formula"`. The `"call"` key is not supported.

--- a/packages/spec/formula-extension-spec.md
+++ b/packages/spec/formula-extension-spec.md
@@ -53,7 +53,7 @@ If a token is typed as a DTCG `dimension`, its resolved `$value` must match DTCG
     "org.dtcg-formulas": {
       "syntax": "scssdef@0.1",
       "definition": "tokens/functions/radius.module.scssdef#radius",
-      "call": "radius({typography.scale.typescale-15}, {shape.ratio.button}, 1px)"
+      "formula": "radius({typography.scale.typescale-15}, {shape.ratio.button}, 1px)"
     }
   }
 }
@@ -63,7 +63,7 @@ If a token is typed as a DTCG `dimension`, its resolved `$value` must match DTCG
 |-------|------|-------------|
 | `syntax` | `string` | Definition format and version. Must match pattern `scssdef@{semver-major.minor}`. |
 | `definition` | `string` | Path to the `.module.scssdef` file and function name, separated by `#`. Path is relative to the token file's repository root. |
-| `call` | `string` | The complete function call expression with resolved or referenced arguments. Token references use DTCG `{path.to.token}` syntax. |
+| `formula` | `string` | The complete function call expression with resolved or referenced arguments. Token references use DTCG `{path.to.token}` syntax. |
 
 ### 4.2 Optional fields (rich form)
 
@@ -73,7 +73,7 @@ If a token is typed as a DTCG `dimension`, its resolved `$value` must match DTCG
     "org.dtcg-formulas": {
       "syntax": "scssdef@0.1",
       "definition": "tokens/functions/radius.module.scssdef#radius",
-      "call": "radius({typography.scale.typescale-15}, {shape.ratio.button}, 1px)",
+      "formula": "radius({typography.scale.typescale-15}, {shape.ratio.button}, 1px)",
       "arguments": {
         "size": "{typography.scale.typescale-15}",
         "ratio": "{shape.ratio.button}",
@@ -132,9 +132,9 @@ tokens/functions/math.module.scssdef#snap
 
 ---
 
-## 7. Call expression format
+## 7. Formula expression format
 
-The `call` field contains a function call expression that:
+The `formula` field contains a function call expression that:
 
 * uses the function name from the definition
 * passes arguments positionally (matching the function signature)
@@ -149,7 +149,7 @@ snap(1.2 * {typography.scale.typescale-10}, 1px, ceil)
 radius({typography.scale.typescale-15}, {shape.ratio.button}, 1px)
 ```
 
-The call expression is a symbolic invocation, not executable code. Consuming toolchains resolve it against the definition and token graph.
+The formula expression is a symbolic invocation, not executable code. Consuming toolchains resolve it against the definition and token graph.
 
 ---
 
@@ -167,7 +167,7 @@ The extension may appear on any DTCG token that has a computed `$value`.
       "org.dtcg-formulas": {
         "syntax": "scssdef@0.1",
         "definition": "tokens/functions/radius.module.scssdef#radius",
-        "call": "radius({typography.scale.typescale-15}, {shape.ratio.button}, 1px)"
+        "formula": "radius({typography.scale.typescale-15}, {shape.ratio.button}, 1px)"
       }
     }
   }
@@ -186,7 +186,7 @@ Compliant toolchains should validate:
 * `syntax` matches the expected version pattern
 * `definition` path resolves to an existing `.module.scssdef` file
 * the fragment references a function that exists in that file
-* `call` uses the correct function name
+* `formula` uses the correct function name
 * argument count matches the function signature (accounting for defaults)
 * if `dependencies` is present, all paths resolve to tokens in the graph
 
@@ -200,7 +200,7 @@ Migration path:
 
 | Before | After |
 |--------|-------|
-| `"com.underline.dtcg": { "formula": "math(ceil(...))" }` | `"org.dtcg-formulas": { "syntax": "scssdef@0.1", "definition": "...#snap", "call": "snap(...)" }` |
+| `"com.underline.dtcg": { "formula": "math(ceil(...))" }` | `"org.dtcg-formulas": { "syntax": "scssdef@0.1", "definition": "...#snap", "formula": "snap(...)" }` |
 
 The `com.underline.dtcg` namespace continues to be used for file-level DTCG spec exception governance. Only the token-level `formula` field moves to the new namespace.
 


### PR DESCRIPTION
Workstream B of the Phase 2 plan: align the spec source on the same key every user-facing doc already uses.

## Summary

- `packages/spec/formula-extension-spec.md` — every `"call":` / `` `call` `` / `Call expression` updated to `"formula":` / `` `formula` `` / `Formula expression`. Six edit sites: required-fields table + JSON block, rich-form JSON block, section 7 heading and prose, section 8 example JSON, validation list, migration table.
- `docs/spec/formula-extension.md` is a VitePress `@include` of the spec source, so the docs site mirrors automatically.
- `.changeset/spec-rename-call-to-formula.md` — patch bump for `@dtcg-formulas/spec` (0.1.0 → 0.1.1).

## Not a breaking change

The syntax version stays at `scssdef@0.1`. No public 0.1.0 tooling consumed either key at runtime — `@dtcg-formulas/parser` and `/registry` ship only as metadata layers — so authors and not-yet-shipped tooling can simply standardize on `"formula"`.

## Verification

- `grep -rn '"call":' packages/ docs/` returns nothing
- `npm run docs:build` clean (VitePress builds, no broken includes)
- `npm run check` (biome) clean
- `npx changeset status` reports the patch bump

## Release flow

Will publish `@dtcg-formulas/spec@0.1.1` via the existing release workflow (still on the Automation token). Trusted publishers can be configured separately and the workflow swap will come in its own PR once trust is set up in npm UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQMhJvH11g1zRCA9MmwWHo)_